### PR TITLE
Fixing Package Name

### DIFF
--- a/src/main/g8/src/main/scala/$package__packaged$/WordCount.scala
+++ b/src/main/g8/src/main/scala/$package__packaged$/WordCount.scala
@@ -1,4 +1,4 @@
-package $organization$.$name$
+package $package$
 
 import java.util.{Calendar, Properties}
 


### PR DESCRIPTION
Currently package was done:
```scala
package $organization$.$name$
```
Changed it to 
```scala
package $package$
```